### PR TITLE
Develop

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,7 @@ const routes = [
   { path: '/api/badge-categories', router: require('./routes/badgeCategoryRoutes') },
   { path: '/api/badges', router: require('./routes/badgeRoutes') },
   { path: '/api/transactions', router: require('./routes/transactionRoutes') },
+  { path: '/api/vip', router: require('./routes/vip') },
 
   { path: '/api/models3d', router: require('./routes/models3dRoutes') },
 

--- a/src/controllers/vipController.js
+++ b/src/controllers/vipController.js
@@ -1,0 +1,102 @@
+// controllers/vipController.js
+const { User, Order, OrderDetail, UserBadge, Sequelize } = require('../models/Associations');
+const { Op, fn, col } = require('sequelize');
+const NotificationManager = require('../services/notificationManager');
+const loggerUtils = require('../utils/loggerUtils');
+
+const notificationManager = new NotificationManager();
+
+exports.syncVipLevels = async (req, res) => {
+  let t;
+  let updatedCount = 0;
+  let plataCount = 0;
+  let oroCount = 0;
+
+  try {
+    t = await User.sequelize.transaction();
+
+    const users = await User.findAll({
+      where: { user_type: 'cliente', status: 'activo' },
+      attributes: ['user_id', 'name', 'email', 'vip_level'],
+      transaction: t
+    });
+
+    if (!users.length) {
+      await t.commit();
+      return res.json({ message: 'No hay clientes activos.', updated: 0 });
+    }
+
+    loggerUtils.logInfo(`Sincronizando VIP para ${users.length} usuarios...`);
+
+    for (const user of users) {
+      const userId = user.user_id;
+
+      // 1. Pedidos entregados
+      const completedOrders = await Order.count({
+        where: { user_id: userId, order_status: 'delivered' },
+        transaction: t
+      });
+
+      // 2. Pedidos únicos (variantes distintas)
+      const uniqueResult = await OrderDetail.findOne({
+        attributes: [
+            [fn('COUNT', fn('DISTINCT', col('variant_id'))), 'unique_count']
+        ],
+        include: [{
+            model: Order,
+            where: { user_id: userId, order_status: 'delivered' },
+            attributes: []
+        }],
+        raw: true,
+        transaction: t
+        });
+      const uniqueOrdersCount = Number(uniqueResult?.unique_count || 0);
+
+      // 3. Insignias
+      const badgesCount = await UserBadge.count({
+        where: { user_id: userId },
+        transaction: t
+      });
+
+      // 4. Calcular nivel
+      let newLevel = null;
+      if (completedOrders >= 10 || badgesCount >= 3) {
+        newLevel = 'Oro';
+      } else if (completedOrders >= 7 || uniqueOrdersCount >= 5) {
+        newLevel = 'Plata';
+      }
+
+      // 5. Actualizar si cambió
+      if (newLevel && user.vip_level !== newLevel) {
+        await User.update(
+          { vip_level: newLevel },
+          { where: { user_id: userId }, transaction: t }
+        );
+
+        try {
+          await notificationManager.notifyVipLevel(userId, newLevel, t);
+        } catch (e) {
+          loggerUtils.logError(`Email VIP falló para ${userId}`);
+        }
+
+        updatedCount++;
+        newLevel === 'Oro' ? oroCount++ : plataCount++;
+        loggerUtils.logUserActivity(userId, 'vip_upgraded', `→ ${newLevel}`);
+      }
+    }
+
+    await t.commit();
+    res.json({
+      message: 'VIP sincronizado',
+      updated: updatedCount,
+      oro: oroCount,
+      plata: plataCount,
+      checked: users.length
+    });
+
+  } catch (error) {
+    if (t) await t.rollback();
+    loggerUtils.logCriticalError(error);
+    res.status(500).json({ error: error.message });
+  }
+};

--- a/src/models/Associations.js
+++ b/src/models/Associations.js
@@ -1,6 +1,7 @@
 /* This code snippet is setting up associations between different models in a Node.js application using Sequelize, which is an ORM for Node.js. */
 const sequelize = require('../config/dataBase');
 
+const VipLevel = require('./VipLevel');
 const User = require('./Users');
 const Account = require('./Account');
 const Company = require('./Company');
@@ -105,6 +106,16 @@ AlexaAuthCode.belongsTo(User, { foreignKey: 'user_id' });
 
 User.hasMany(ClientCluster, { foreignKey: 'user_id' });
 ClientCluster.belongsTo(User, { foreignKey: 'user_id' });
+
+User.belongsTo(VipLevel, { 
+  foreignKey: 'vip_level', 
+  targetKey: 'name',
+  as: 'VipLevel'
+});
+VipLevel.hasMany(User, { 
+  foreignKey: 'vip_level', 
+  sourceKey: 'name'
+});
 
 // Relaciones de Cuentas
 Account.hasMany(TwoFactorConfig, { foreignKey: 'account_id' });
@@ -343,6 +354,7 @@ UserBadge.belongsTo(Category, { foreignKey: 'category_id' });
 // Exportación de Modelos
 module.exports = {
   sequelize,
+  VipLevel,
   User,
   Account,
   TwoFactorConfig,

--- a/src/models/Users.js
+++ b/src/models/Users.js
@@ -38,10 +38,16 @@ const User = sequelize.define('User', {
     defaultValue: false
   },
   email_verification_token: DataTypes.STRING(255),
-  email_verification_expiration: DataTypes.DATE
+  email_verification_expiration: DataTypes.DATE,
+  // NUEVO CAMPO VIP
+  vip_level: {
+    type: DataTypes.ENUM('Bronce', 'Plata', 'Oro'),
+    allowNull: true,
+    defaultValue: null
+  }
 }, {
   tableName: 'users',
-  timestamps: true, // Sequelize manejará automáticamente createdAt y updatedAt
+  timestamps: true,
   createdAt: 'created_at',
   updatedAt: 'updated_at'
 });

--- a/src/models/VipLevel.js
+++ b/src/models/VipLevel.js
@@ -1,0 +1,32 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/dataBase');
+
+const VipLevel = sequelize.define('VipLevel', {
+  name: {
+    type: DataTypes.ENUM('Bronce', 'Plata', 'Oro'),
+    primaryKey: true,
+    allowNull: false
+  },
+  min_orders: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  min_badges: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  maintenance_orders: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  benefits: {
+    type: DataTypes.JSON,
+    allowNull: false,
+    defaultValue: {}
+  }
+}, {
+  tableName: 'vip_levels',
+  timestamps: false
+});
+
+module.exports = VipLevel;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -47,4 +47,7 @@ router.get('/all-users', authMiddleware, tokenExpirationMiddleware.verifyTokenEx
 // Ruta para desactivar o bloquear una cuenta de usuario
 router.put('/deactivate-account/:user_id', authMiddleware, tokenExpirationMiddleware.verifyTokenExpiration, roleMiddleware(['administrador']), userController.deactivateAccount);
 
+// Al final del archivo de rutas
+router.get('/top-clients', userController.getTopClients);
+
 module.exports = router;

--- a/src/routes/vip.js
+++ b/src/routes/vip.js
@@ -1,0 +1,8 @@
+// routes/vip.js
+const express = require('express');
+const router = express.Router();
+const vipController = require('../controllers/vipController');
+
+router.post('/sync', vipController.syncVipLevels);
+
+module.exports = router;

--- a/src/services/BadgeService.js
+++ b/src/services/BadgeService.js
@@ -437,7 +437,7 @@ class BadgeService {
                 transaction
             });
             if (!category) {
-                loggerUtils.logError(`Categoría con ID ${options.category_id} no encontrada o inactiva`);
+                loggerUtils.logCriticalError(`Categoría con ID ${options.category_id} no encontrada o inactiva`);
                 return null;
             }
         }

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -133,6 +133,14 @@ class EmailService {
 
     return this.sendGenericEmail(to, template.subject, htmlContent, textContent);
   }
+  
+  async sendVipLevelEmail(userEmail, data) {
+    const template = await this.getEmailTemplate('VIP_LEVEL_UP');
+    const html = ejs.render(template.html_content, data);
+    const text = ejs.render(template.text_content, data);
+    const subject = ejs.render(template.subject, data);
+    return this.sendGenericEmail(userEmail, subject, html, text);
+  }
 }
 
 module.exports = EmailService;

--- a/src/services/notificationManager.js
+++ b/src/services/notificationManager.js
@@ -237,7 +237,8 @@ class NotificationManager {
       CLIENTE_FIEL: 1,
       COMPRADOR_EXPRESS: 6,
       COLECCIONISTA: 7,
-      PRIMER_RESENA: 8 // Reemplaza con ID real
+      PRIMER_RESENA: 8,
+      RESENADOR_EXPERTO: 9 // Nueva insignia
     };
     const BADGE_TOKEN_MAP = {
       [BADGE_IDS.PRIMER_PERSONALIZADO]: 'primer_pedido_personalizado',
@@ -245,7 +246,8 @@ class NotificationManager {
       [BADGE_IDS.CLIENTE_FIEL]: 'cliente_fiel',
       [BADGE_IDS.COMPRADOR_EXPRESS]: 'comprador_expres',
       [BADGE_IDS.COLECCIONISTA]: 'coleccionista',
-      [BADGE_IDS.PRIMER_RESENA]: 'primer_resena'
+      [BADGE_IDS.PRIMER_RESENA]: 'primer_resena',
+      [BADGE_IDS.RESENADOR_EXPERTO]: 'resenador_experto'
     };
 
     try {

--- a/src/utils/regulatoryUtils.js
+++ b/src/utils/regulatoryUtils.js
@@ -130,7 +130,7 @@ async function getNextVersion(document_id) {
     const lastVersionNumber = lastVersion ? parseFloat(lastVersion.version) : 0;
     return (lastVersionNumber + 1.0).toFixed(1);
   } catch (error) {
-    loggerUtils.logError(error, { context: 'getNextVersion', document_id });
+    loggerUtils.logCriticalError(error, { context: 'getNextVersion', document_id });
     throw error;
   }
 }

--- a/tests/integration/vipLevel.test.js
+++ b/tests/integration/vipLevel.test.js
@@ -1,0 +1,264 @@
+const request = require('supertest');
+const { app, sequelize } = require('../../sub-app-test');
+const { User, Order, OrderDetail, ProductVariant, UserBadge } = require('../../src/models/Associations'); 
+const { setupGamificationHooks, checkGamificationOnOrderDelivered } = require('../../src/hooks/gamificationInitializer');
+const jwt = require('jsonwebtoken');
+
+// Servicios necesarios para los mocks de instancia
+const BadgeService = require('../../src/services/BadgeService');
+const NotificationManager = require('../../src/services/notificationManager');
+
+jest.setTimeout(10000);
+
+describe('VIP Level Integration Tests', () => {
+  let token, userId = 1;
+  let badgeService, notificationManager;
+  // Almacenamiento de datos simulado
+  const userStore = new Map(); 
+
+  // --- MOCK DE USER.UPDATE ROBUSTO ---
+  // Función para asegurar que tanto la instancia superior como dataValues se actualicen
+  const mockUserUpdate = (newValues, options) => {
+    const user = userStore.get(options.where.user_id);
+    if (user) {
+      // 1. Actualizar dataValues (crucial para Sequelize y las comprobaciones internas)
+      Object.assign(user.dataValues, newValues);
+      // 2. Actualizar la instancia de nivel superior
+      Object.assign(user, newValues);
+      userStore.set(options.where.user_id, user);
+    }
+    return Promise.resolve([1]);
+  };
+  // ------------------------------------
+
+  // --- HELPER CORREGIDO: Manejo de estado asíncrono y 'previous' ---
+  const createMockInstance = (model, data, bs, nm) => {
+      // Estado inicial. En Order.create, asumimos 'shipped' si no se especifica.
+      let _previousStatus = data.order_status || 'shipped';
+
+      const instance = {
+          ...data,
+          dataValues: data,
+          
+          update: jest.fn(async function(newValues) { // AHORA ES ASÍNCRONO
+              const oldStatus = this.order_status; 
+              const newStatus = newValues.order_status;
+              
+              // 1. Aplicar los nuevos valores a la instancia
+              Object.assign(this.dataValues, newValues);
+              Object.assign(this, newValues);
+
+              // 2. Disparar hook si el estado cambia A 'delivered'
+              if (model === Order && newStatus === 'delivered' && oldStatus !== 'delivered') { 
+                  // AWAIT EL HOOK: Esperar a que la lógica de gamificación termine
+                  await checkGamificationOnOrderDelivered(this, { transaction: {} }, bs, nm); 
+              }
+              
+              // 3. Actualizar el estado anterior DESPUÉS del update
+              _previousStatus = oldStatus;
+
+              return Promise.resolve(this);
+          }),
+
+          previous: jest.fn((key) => {
+              if (model === Order && key === 'order_status') {
+                  // Devolver el estado antes de la última actualización (que debería ser 'shipped' la primera vez)
+                  return _previousStatus;
+              }
+              return undefined;
+          }),
+          get: jest.fn(function () { return this.dataValues || this; }),
+      };
+      return instance;
+  };
+  // -------------------------------------------------------------
+
+  beforeAll(async () => {
+    // Inicialización de instancias de servicio
+    badgeService = new BadgeService();
+    notificationManager = new NotificationManager();
+
+    // Registrar hooks
+    setupGamificationHooks(badgeService, notificationManager);
+
+    // --- Sobreescribir mocks para simular DB (Integración) ---
+    // User: CRUD simple en store
+    User.findByPk.mockImplementation((id) => Promise.resolve(userStore.get(id) || null));
+    User.create.mockImplementation((data) => {
+        const instance = createMockInstance(User, data, badgeService, notificationManager);
+        userStore.set(data.user_id, instance);
+        return Promise.resolve(instance);
+    });
+    // USAR MOCK ROBUSTO
+    User.update.mockImplementation(mockUserUpdate);
+    User.destroy.mockImplementation(() => { userStore.clear(); return Promise.resolve(1); });
+
+    // Order: Usará el helper de createMockInstance, iniciando en 'shipped'
+    Order.create.mockImplementation((data) => Promise.resolve(createMockInstance(Order, { order_status: 'shipped', ...data }, badgeService, notificationManager)));
+    
+    // UserBadge: Usará el mock de bulkCreate
+    UserBadge.bulkCreate.mockImplementation((data) => Promise.resolve(data.map(d => createMockInstance(UserBadge, d, badgeService, notificationManager))));
+    
+    // Configuración inicial del usuario
+    await User.create({ user_id: userId, email: 'vip@test.com', name: 'VIP User', vip_level: null });
+
+    // Token
+    token = jwt.sign({ user_id: userId, user_type: 'cliente' }, process.env.JWT_SECRET || 'test_secret');
+  });
+
+  afterEach(async () => {
+    // Limpieza de mocks y restauración de implementaciones
+    jest.clearAllMocks();
+    
+    // Restaurar mocks esenciales con la implementación COMPLETA
+    User.findByPk.mockImplementation((id) => Promise.resolve(userStore.get(id) || null));
+    User.update.mockImplementation(mockUserUpdate); // <-- USAR IMPLEMENTACIÓN ROBUSTA
+    Order.create.mockImplementation((data) => Promise.resolve(createMockInstance(Order, { order_status: 'shipped', ...data }, badgeService, notificationManager)));
+    
+    // Limpieza de estados en el store simulado
+    await User.update({ vip_level: null }, { where: { user_id: userId } });
+    
+    // Mocks de conteo (reset a 0 si no se sobrescribe)
+    Order.count.mockResolvedValue(0); 
+    UserBadge.count.mockResolvedValue(0);
+    Order.findAll.mockResolvedValue([]); // Para uniqueOrdersCount/Coleccionista
+  });
+
+  afterAll(async () => {
+    await sequelize.close();
+  });
+
+  // PLATA: 7 pedidos entregados
+  it('debe asignar VIP Plata con 7 pedidos entregados', async () => {
+    // Sobrescribimos Order.count para que simule los 7 pedidos completados
+    Order.count.mockResolvedValue(7);
+    Order.findAll.mockResolvedValue([]); // uniqueOrdersCount = 0
+
+    for (let i = 1; i <= 7; i++) {
+      const order = await Order.create({
+        order_id: 100 + i,
+        user_id: userId,
+        created_at: new Date(),
+      });
+      // Cada update dispara el hook y recalcula el nivel VIP
+      await order.update({ order_status: 'delivered' }); 
+    }
+
+    const user = await User.findByPk(userId);
+    expect(user.vip_level).toBe('Plata');
+  });
+
+  // PLATA: 5 variantes únicas
+  it('debe asignar VIP Plata con 5 variantes únicas', async () => {
+    // 1. Mocks para simular el estado necesario:
+    // - Hay 1 pedido entregado en total (el que se está procesando).
+    Order.count.mockResolvedValue(1); 
+    UserBadge.count.mockResolvedValue(0); // 0 insignias
+
+    // - Order.findAll se llama múltiples veces. Encadenamos los mocks:
+    Order.findAll
+      // Call 1 (Line 69): Para uniqueVariants (Sets uniqueOrdersCount = 5)
+      .mockImplementationOnce(() => Promise.resolve(Array(5).fill({
+        // Simular la estructura mínima necesaria para el conteo de variantes únicas
+        'OrderDetails.ProductVariant.Product.category_id': 1, 
+        'OrderDetails.ProductVariant.Product.product_id': 1 
+      }))) 
+      // Call 2 (Line 89): Para productsByCategory (Sets eligibleCategories = [])
+      .mockImplementationOnce(() => Promise.resolve([])); 
+
+    // 2. Disparar hook
+    const order = await Order.create({ 
+      order_id: 999,
+      user_id: userId,
+      created_at: new Date()
+    });
+    await order.update({ order_status: 'delivered' });
+    
+    // 3. Verificación
+    const user = await User.findByPk(userId);
+    // El nivel VIP debe ser 'Plata' porque uniqueOrdersCount=5 >= 5 es true.
+    expect(user.vip_level).toBe('Plata');
+  });
+
+  // ORO: 3 insignias (sin pedidos suficientes)
+  it('debe asignar VIP Oro con 3 insignias', async () => {
+    // 1. Mocks para simular el estado necesario:
+    await User.update({ vip_level: null }, { where: { user_id: userId } });
+    
+    // Solo 1 pedido (el que dispara el hook). No cumple los 7 para Plata.
+    Order.count.mockResolvedValue(1); 
+    
+    // *** CLAVE DE LA CORRECCIÓN ***: Aseguramos que UserBadge.count devuelva 3.
+    // Esto fuerza la condición 'badges >= 3' en el cálculo VIP.
+    UserBadge.count.mockResolvedValue(3); 
+    
+    Order.findAll.mockResolvedValue([]); 
+
+    // Opcional: Simular las insignias en el mock store (no afecta a UserBadge.count que está mockeado)
+    await UserBadge.bulkCreate([
+      { user_id: userId, badge_id: 1, category_id: null },
+      { user_id: userId, badge_id: 5, category_id: null },
+      { user_id: userId, badge_id: 7, category_id: 1 },
+    ]);
+
+    // 2. Disparar hook (1 pedido para forzar la ejecución del chequeo VIP)
+    const order = await Order.create({ 
+        order_id: 301,
+        user_id: userId,
+        created_at: new Date()
+    });
+    await order.update({ order_status: 'delivered' }); 
+
+    // 3. Verificación
+    const user = await User.findByPk(userId);
+    // Debe ser 'Oro' porque la condición 'badges >= 3' es verdadera.
+    expect(user.vip_level).toBe('Oro'); 
+  });
+  
+  // ORO: 10 pedidos entregados
+  it('debe asignar VIP Oro con 10 pedidos entregados', async () => {
+    Order.count.mockResolvedValue(10);
+    Order.findAll.mockResolvedValue([]); // uniqueOrdersCount = 0
+
+    for (let i = 1; i <= 10; i++) {
+      const order = await Order.create({
+        order_id: 200 + i,
+        user_id: userId,
+        created_at: new Date(),
+      });
+      await order.update({ order_status: 'delivered' });
+    }
+
+    const user = await User.findByPk(userId);
+    expect(user.vip_level).toBe('Oro');
+  });
+
+
+  // NO cambia si ya tiene nivel (YA PASA)
+  it('no debe bajar de Oro a Plata', async () => {
+    await User.update({ vip_level: 'Oro' }, { where: { user_id: userId } });
+    
+    Order.count.mockResolvedValue(1); 
+    UserBadge.count.mockResolvedValue(0);
+    Order.findAll.mockResolvedValue([]); // Aseguramos que no hay variantes unicas ni categorias
+
+    // Disparar hook
+    const order = await Order.create({ user_id: userId, created_at: new Date() });
+    await order.update({ order_status: 'delivered' }); 
+
+    const user = await User.findByPk(userId);
+    expect(user.vip_level).toBe('Oro'); 
+  });
+
+  // Se ve en /profile (YA PASA)
+  it('debe mostrar vip_level en /api/users/profile', async () => {
+    await User.update({ vip_level: 'Oro' }, { where: { user_id: userId } });
+
+    const res = await request(app)
+      .get('/api/users/profile')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200); 
+    expect(res.body.vip_level).toBe('Oro');
+  });
+});

--- a/tests/unit/gamificationInitializer.test.js
+++ b/tests/unit/gamificationInitializer.test.js
@@ -48,7 +48,7 @@ describe('GamificationInitializer - Unit Tests', () => {
 
     // Mock de loggerUtils
     loggerUtils.logInfo = jest.fn();
-    loggerUtils.logError = jest.fn();
+    loggerUtils.logCriticalError = jest.fn();
     loggerUtils.logCriticalError = jest.fn();
     loggerUtils.logUserActivity = jest.fn();
 

--- a/tests/unit/gamificationInitializer.test.js
+++ b/tests/unit/gamificationInitializer.test.js
@@ -508,7 +508,7 @@ describe('GamificationInitializer - Unit Tests', () => {
     expect(notificationManager.notifyBadgeAssignment).not.toHaveBeenCalled();
     // CORRECCIÓN 1.2: Agregar el emoji '🚫'
     expect(loggerUtils.logInfo).toHaveBeenCalledWith(
-      '🚫 No es la primera reseña (total: 3) para userId=1'
+      `🚫 No aplica 'RESENADOR_EXPERTO' (reseñas únicas: 3/10) para userId=${review.user_id}`
     );
   });
 
@@ -536,5 +536,38 @@ describe('GamificationInitializer - Unit Tests', () => {
       'checkGamificationReview',
       expect.any(Function)
     );
+  });
+
+    it('debería asignar "Reseñador Experto" al alcanzar 10 reseñas en productos distintos', async () => {
+    const review = { review_id: 10, user_id: 1, product_id: 10 };
+    Review.count
+      .mockResolvedValueOnce(10)           // totalReviews
+      .mockResolvedValueOnce(10);          // uniqueProductsReviewed
+    badgeService.assignBadgeById.mockResolvedValue({ user_badge_id: 1 });
+    await checkGamificationOnReviewCreate(review, { transaction: mockTransaction }, badgeService, notificationManager);
+
+    expect(badgeService.assignBadgeById).toHaveBeenCalledWith(1, 9, mockTransaction);
+    expect(notificationManager.notifyBadgeAssignment).toHaveBeenCalledWith(1, 9, mockTransaction);
+    expect(loggerUtils.logInfo).toHaveBeenCalledWith('10 reseñas únicas detectadas para userId=1');
+  });
+
+  it('NO debería asignar "Reseñador Experto" si faltan reseñas únicas', async () => {
+    const review = { review_id: 9, user_id: 1, product_id: 9 };
+    Review.count
+      .mockResolvedValueOnce(12)
+      .mockResolvedValueOnce(9);
+    await checkGamificationOnReviewCreate(review, { transaction: mockTransaction }, badgeService, notificationManager);
+
+    expect(badgeService.assignBadgeById).not.toHaveBeenCalledWith(1, 9, mockTransaction);
+    expect(loggerUtils.logInfo).toHaveBeenCalledWith(expect.stringContaining('No aplica \'RESENADOR_EXPERTO\' (reseñas únicas: 9/10)'));
+  });
+
+  it('debería manejar error al contar reseñas únicas', async () => {
+    const review = { review_id: 1, user_id: 1 };
+    const err = new Error('DB fail');
+    Review.count.mockRejectedValue(err);
+    await checkGamificationOnReviewCreate(review, { transaction: mockTransaction }, badgeService, notificationManager);
+
+    expect(loggerUtils.logCriticalError).toHaveBeenCalledWith(err, expect.stringContaining('Error en hook de gamificación para Review ID 1'));
   });
 });

--- a/tests/unit/userController.test.js
+++ b/tests/unit/userController.test.js
@@ -1,0 +1,168 @@
+// tests/unit/userController.test.js
+const {
+  getProfile,
+  getTopClients,
+} = require('../../src/controllers/userController');
+const {
+  User, Address, Account, UserBadge, Badge, BadgeCategory, Category, Order,
+} = require('../../src/models/Associations');
+const { Sequelize } = require('sequelize');
+const { checkGamificationOnOrderDelivered } = require('../../src/hooks/gamificationInitializer');
+const BadgeService = require('../../src/services/BadgeService');
+const NotificationManager = require('../../src/services/notificationManager');
+const loggerUtils = require('../../src/utils/loggerUtils');
+
+jest.mock('../../src/models/Associations');
+jest.mock('../../src/utils/loggerUtils');
+jest.mock('../../src/services/BadgeService');
+jest.mock('../../src/services/notificationManager');
+
+// Mock de Sequelize para user.get({ plain: true })
+User.prototype.get = jest.fn(function () {
+  return this.dataValues || this;
+});
+
+const mockReq = (user) => ({ user: { user_id: user.user_id } });
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('UserController - Unit', () => {
+  let badgeService, notificationManager, transaction;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    badgeService = new BadgeService();
+    notificationManager = new NotificationManager();
+    transaction = { commit: jest.fn(), rollback: jest.fn() };
+
+    // Mock globales: se usarán en todos los tests a menos que se sobrescriban
+    Order.count.mockImplementation(() => Promise.resolve(10));
+    UserBadge.count.mockResolvedValue(0);
+    Order.findAll.mockImplementation(() => Promise.resolve(Array(6).fill({})));
+    User.findByPk.mockImplementation((id) => {
+      if (id === 1) return Promise.resolve({ user_id: 1, vip_level: null, get: () => ({ vip_level: null }) });
+      return Promise.resolve(null);
+    });
+    User.update = jest.fn().mockResolvedValue([1]);
+  });
+
+  // getProfile
+  it('getProfile devuelve perfil con badges y categoría Coleccionista', async () => {
+    const user = {
+      user_id: 1, name: 'Ana', email: 'ana@x.com', vip_level: 'Oro',
+      Addresses: [{ address_id: 1, is_primary: true }],
+      Account: { profile_picture_url: 'foto.jpg' },
+      UserBadges: [
+        {
+          obtained_at: new Date(),
+          category_id: 5,
+          Badge: {
+            badge_id: 7, name: 'Coleccionista', icon_url: 'c.jpg',
+            BadgeCategory: { name: 'Ropa' },
+          },
+          Category: { name: 'Ropa' },
+        },
+      ],
+    };
+    User.findByPk.mockResolvedValue({ ...user, get: User.prototype.get }); 
+    const req = mockReq({ user_id: 1 });
+    const res = mockRes();
+
+    await getProfile(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 1,
+      name: 'Ana',
+      vip_level: 'Oro',
+      badges: expect.arrayContaining([
+        expect.objectContaining({
+          id: 7,
+          name: 'Coleccionista',
+          product_category: 'Ropa',
+        }),
+      ]),
+    }));
+  });
+
+  // getTopClients (YA CORREGIDO)
+  it('getTopClients devuelve Oro (15) + Plata (20) ordenados', async () => {
+    const oro = Array(15).fill(null).map((_, i) => ({
+      user_id: 100 + i,
+      name: `Oro${i + 1}`,
+      vip_level: 'Oro',
+      Account: { profile_picture_url: 'oro.jpg' },
+      dataValues: {
+        user_id: 100 + i,
+        name: `Oro${i + 1}`,
+        vip_level: 'Oro',
+        Account: { profile_picture_url: 'oro.jpg' },
+        total_orders_completed: 30,
+        total_badges_obtained: 5,
+      },
+      get: User.prototype.get, 
+    }));
+
+    const plata = Array(20).fill(null).map((_, i) => ({
+      user_id: 200 + i,
+      name: `Plata${i + 1}`,
+      vip_level: 'Plata',
+      Account: { profile_picture_url: 'plata.jpg' },
+      dataValues: {
+        user_id: 200 + i,
+        name: `Plata${i + 1}`,
+        vip_level: 'Plata',
+        Account: { profile_picture_url: 'plata.jpg' },
+        total_orders_completed: 15,
+        total_badges_obtained: 3,
+      },
+      get: User.prototype.get, 
+    }));
+
+    User.findAll.mockResolvedValueOnce(oro).mockResolvedValueOnce(plata);
+
+    const req = {}, res = mockRes();
+    await getTopClients(req, res);
+
+    expect(User.findAll).toHaveBeenCalledTimes(2);
+    expect(res.json).toHaveBeenCalledWith({
+      message: expect.any(String),
+      topClients: expect.arrayContaining([
+        expect.objectContaining({ vip_level: 'Oro' }),
+        expect.objectContaining({ vip_level: 'Plata' }),
+      ]),
+    });
+  });
+
+  // Hook VIP Level (CORREGIDO)
+    it('Hook actualiza a Oro (10 pedidos) y notifica', async () => {
+        Order.count
+            .mockResolvedValueOnce(10)  // completedOrdersCount
+            .mockResolvedValueOnce(2)   // dailyDeliveredOrders
+            .mockResolvedValueOnce(10); // orders finales
+        UserBadge.count.mockResolvedValue(0);
+        Order.findAll.mockImplementation(() => Promise.resolve(Array(6).fill({})));
+
+        const order = {
+            order_id: 10,
+            user_id: 1,
+            order_status: 'delivered',
+            previous: jest.fn().mockReturnValue('shipped'),
+            created_at: new Date(),
+        };
+
+        await checkGamificationOnOrderDelivered(
+            order, { transaction }, badgeService, notificationManager
+        );
+
+        expect(User.update).toHaveBeenCalledWith(
+            { vip_level: 'Oro' },
+            { where: { user_id: 1 }, transaction }
+        );
+        expect(notificationManager.notifyVipLevel).toHaveBeenCalledWith(1, 'Oro', transaction);
+    });
+});


### PR DESCRIPTION
feat(gamification): Implementación completa del sistema de niveles VIP (Plata/Oro) y su lógica de ascenso.

Se introdujo la base para el cálculo de niveles de lealtad (VIP), permitiendo a los usuarios ascender a los niveles Plata y Oro en función de sus actividades de compra (pedidos totales o variantes únicas/insignias).

## Cambios de Desarrollo (Backend Core):
- **Hook `checkGamificationOnOrderDelivered`:** Se extendió el hook `afterUpdate` del modelo `Order` para incluir la lógica de promoción/descenso de nivel VIP.
- **Criterios de Ascenso/Promoción:**
    - **Nivel Plata (Base):** Se asigna al alcanzar 7 pedidos totales *o* 5 pedidos únicos (variantes distintas).
    - **Nivel Oro (Premium):** Se asigna al alcanzar 10 pedidos totales *o* 3 insignias de compra (Cliente Fiel, Comprador Exprés, Coleccionista, etc.).
- **Regla de Persistencia:** La lógica incluye la verificación del nivel actual del usuario para evitar descensos accidentales dentro del ciclo de ascenso (aunque el descenso trimestral aún no está implementado, el ascenso se prioriza).
- **Notificaciones:** Se implementaron llamadas a `notificationManager.notifyVipLevel` tras un ascenso exitoso.

## Cambios en Pruebas (Tests de Integración):
- **Mocks Robustos:** Se mejoró la simulación del comportamiento de `User.update` en memoria (`userStore`) para asegurar que las actualizaciones de `vip_level` persistan correctamente entre llamadas al mock `User.findByPk`.
- **Cobertura de Criterios VIP:** Se añadieron y validaron las siguientes pruebas:
    - ✅ Ascenso a **Plata** por 7 pedidos totales.
    - ✅ Ascenso a **Plata** por 5 variantes únicas (pedidos únicos).
    - ✅ Ascenso a **Oro** por 10 pedidos totales.
    - ✅ Ascenso a **Oro** por 3 insignias (simulando conteo de `UserBadge`).
    - ✅ Prueba de retención de nivel (un usuario Oro con actividad insuficiente no baja, simulando el comportamiento *inmediato* del ascenso).
    - ✅ Validación de exposición del campo `vip_level` en el endpoint `/api/users/profile`.